### PR TITLE
<> operator returns an element even in list context

### DIFF
--- a/lib/Iterator/Simple.pm
+++ b/lib/Iterator/Simple.pm
@@ -118,19 +118,15 @@ sub list {
 	}
 	if(blessed $self) {
 		if($self->isa(ITERATOR_CLASS)) {
-			my(@list, $val);
-			push @list, $val while defined($val = $self->());
-			return \@list;
+			return $self->list;
 		}
 		my $method;
 		if($method = overload::Method($self,'@{}')) {
 			return $method->($self);
 		}
 		if($method = $self->can('__iter__')) {
-			my(@list, $val);
 			my $iter = $method->($self);
-			push @list, $val while defined($val = $iter->());
-			return \@list;
+			return $iter->list;
 		}
 		if($method = overload::Method($self, '<>') || $self->can('next')) {
 			my(@list, $val);
@@ -366,11 +362,7 @@ sub iarray {
 
 	use Carp;
 	use overload (
-		'<>'  => sub {
-			wantarray
-			? @{Iterator::Simple::list($_[0])}
-			: $_[0]->();
-		},
+		'<>'  => sub { wantarray ? @{$_[0]->list} : $_[0]->() },
 		'|' => 'filter',
 		fallback => 1,
 	);
@@ -394,6 +386,11 @@ sub iarray {
 	*slice  = \&Iterator::Simple::islice;
 	sub head { Iterator::Simple::ihead($_[1], $_[0]); }
 	sub skip { Iterator::Simple::iskip($_[1], $_[0]); }
+	sub list {
+		my(@list, $val);
+		push @list, $val while defined($val = $_[0]->());
+		return \@list;
+	}
 }
 
 1;
@@ -779,6 +776,8 @@ is equivalent to:
 =item $iterator->head($count)
 
 =item $iterator->skip($count)
+
+=item $iterator->list()
 
 For example, $iterator->flatten() is equivalent to
 C<iflatten $iterator>.

--- a/lib/Iterator/Simple.pm
+++ b/lib/Iterator/Simple.pm
@@ -366,7 +366,11 @@ sub iarray {
 
 	use Carp;
 	use overload (
-		'<>'  => 'next',
+		'<>'  => sub {
+			wantarray
+			? @{Iterator::Simple::list($_[0])}
+			: $_[0]->();
+		},
 		'|' => 'filter',
 		fallback => 1,
 	);

--- a/t/10_basic.t
+++ b/t/10_basic.t
@@ -1,4 +1,4 @@
-use Test::More tests => 5;
+use Test::More tests => 6;
 use strict;
 use warnings;
 
@@ -52,6 +52,13 @@ ok( mk_itr(1,5), 'iterator creation' );
 		push @res, $_;
 	}
 	is_deeply ( \@res, [1,2,3,4,5], '"<>" overload' );
+}
+
+#6
+{
+	$itr = mk_itr(1,5);
+	my @res = <$itr>;
+	is_deeply ( \@res, [1,2,3,4,5], '"<>" overload (list context)' );
 }
 
 # @{} overloads could cause confusion


### PR DESCRIPTION
`my @elements = <$iter>` returns only the first element of $iter, but <> operater should return all elements in list context.

POD says:

> If a `<FILEHANDLE>` is used in a context that is looking for a list, a list comprising all input lines is returned, one line per list element.
> https://perldoc.perl.org/perlop.html